### PR TITLE
(QE-189)  Puppet Acceptance needs to be able to handle rhel 4

### DIFF
--- a/lib/puppet_acceptance/host/unix/pkg.rb
+++ b/lib/puppet_acceptance/host/unix/pkg.rb
@@ -7,9 +7,9 @@ module Unix::Pkg
   end
 
   def install_package name
-    if self['platform'] =~ /(el-4)|(redhat-4)/
+    if self['platform'] =~ /el-4/
       @logger.debug("Package installation not supported on rhel4")
-    elsif self['platform'] =~ /(fedora)|(centos)|(el)|(redhat)/
+    elsif self['platform'] =~ /(fedora)|(centos)|(el)/
       execute("yum -y install #{name}")
     elsif self['platform'] =~ /(ubuntu)|(debian)/
       execute("apt-get update")

--- a/lib/puppet_acceptance/host/unix/pkg.rb
+++ b/lib/puppet_acceptance/host/unix/pkg.rb
@@ -7,7 +7,9 @@ module Unix::Pkg
   end
 
   def install_package name
-    if self['platform'] =~ /(fedora)|(centos)|(el)/
+    if self['platform'] =~ /(el-4)|(redhat-4)/
+      @logger.debug("Package installation not supported on rhel4")
+    elsif self['platform'] =~ /(fedora)|(centos)|(el)|(redhat)/
       execute("yum -y install #{name}")
     elsif self['platform'] =~ /(ubuntu)|(debian)/
       execute("apt-get update")

--- a/lib/puppet_acceptance/hypervisor/vcloud.rb
+++ b/lib/puppet_acceptance/hypervisor/vcloud.rb
@@ -116,7 +116,7 @@ module PuppetAcceptance
         @logger.notify "Waiting for #{h['vmhostname']} DNS resolution"
         try = 1
         last_wait = 0
-        wait = 1
+        wait = 3
 
         begin
           Socket.getaddrinfo(h['vmhostname'], nil)

--- a/lib/puppet_acceptance/utils/repo_control.rb
+++ b/lib/puppet_acceptance/utils/repo_control.rb
@@ -13,7 +13,7 @@ module PuppetAcceptance
       end
 
       def epel_info_for! host
-        version = host['platform'].match(/el-(\d+)/)[1]
+        version = host['platform'].match(/((redhat)|(el))-(\d+)/)[1]
         if version == '6'
           pkg = 'epel-release-6-8.noarch.rpm'
           url = "http://mirror.itc.virginia.edu/fedora-epel/6/i386/#{pkg}"
@@ -72,7 +72,7 @@ module PuppetAcceptance
         #only supports el-* platforms
         @hosts.each do |host|
           case
-          when host['platform'] =~ /el-/
+          when host['platform'] =~ /(el-(5|6))|(redhat-(5|6))/
             result = host.exec(Command.new('rpm -qa | grep epel-release'), :acceptable_exit_codes => [0,1])
             if result.exit_code == 1
               url = epel_info_for! host

--- a/lib/puppet_acceptance/utils/repo_control.rb
+++ b/lib/puppet_acceptance/utils/repo_control.rb
@@ -13,7 +13,7 @@ module PuppetAcceptance
       end
 
       def epel_info_for! host
-        version = host['platform'].match(/((redhat)|(el))-(\d+)/)[1]
+        version = host['platform'].match(/el-(\d+)/)[1]
         if version == '6'
           pkg = 'epel-release-6-8.noarch.rpm'
           url = "http://mirror.itc.virginia.edu/fedora-epel/6/i386/#{pkg}"
@@ -72,7 +72,7 @@ module PuppetAcceptance
         #only supports el-* platforms
         @hosts.each do |host|
           case
-          when host['platform'] =~ /(el-(5|6))|(redhat-(5|6))/
+          when host['platform'] =~ /el-(5|6)/
             result = host.exec(Command.new('rpm -qa | grep epel-release'), :acceptable_exit_codes => [0,1])
             if result.exit_code == 1
               url = epel_info_for! host


### PR DESCRIPTION
- skips epel installation on rhel4
- skips package installation on rhel4
- increased timeout for vcloud dns resolution
