### PR TITLE
(maint) Fix with_puppet_running_on for testing with packages

### DIFF
--- a/lib/puppet_acceptance/dsl/helpers.rb
+++ b/lib/puppet_acceptance/dsl/helpers.rb
@@ -1,4 +1,5 @@
 require 'resolv'
+require 'inifile'
 require 'puppet_acceptance/dsl/outcomes'
 
 module PuppetAcceptance
@@ -288,11 +289,20 @@ module PuppetAcceptance
       # @param [Host] hosts        One object that act like Host
       #
       # @param [Hash{Symbol=>String}]
-      #                            config_opts Represent puppet settings.
+      #                            conf_opts Represent puppet settings.
       #                            Sections of the puppet.conf may be
       #                            specified, if no section is specified the
       #                            a puppet.conf file will be written with the
-      #                            options put in a section named after [mode].
+      #                            options put in a section named after [mode]
+      #
+      #                            There is a special setting for command_line
+      #                            arguments such as --debug or --logdest, which
+      #                            cannot be set in puppet.conf.   For example:
+      #
+      #                            :__commandline_args__ => '--logdest /tmp/a.log'
+      #
+      #                            These will only be applied when starting a FOSS
+      #                            master, as a pe master is just bounced.
       #
       # @param [Block]             block The point of this method, yields so
       #                            tests may be ran. After the block is finished
@@ -314,58 +324,77 @@ module PuppetAcceptance
       #
       # @api dsl
       def with_puppet_running_on host, conf_opts, testdir = host.tmpdir(File.basename(@path)), &block
+        raise(ArgumentError, "with_puppet_running_on's conf_opts must be a Hash. You provided a #{conf_opts.class}: '#{conf_opts}'") if !conf_opts.kind_of?(Hash)
+        cmdline_args = conf_opts.delete(:__commandline_args__)
+
         begin
-          backup_file host, host['puppetpath'], testdir, 'puppet.conf'
+          backup_file = backup_the_file(host, host['puppetpath'], testdir, 'puppet.conf')
           lay_down_new_puppet_conf host, conf_opts, testdir
 
           if host.is_pe?
-            bounce_service( 'pe-httpd' )
-
+            bounce_service( host, 'pe-httpd' )
           else
-            start_puppet_from_source_on!( host )
+            puppet_master_started = start_puppet_from_source_on!( host, cmdline_args )
           end
 
           yield self if block_given?
+
+        rescue Exception => early_exception
+          original_exception = RuntimeError.new("PuppetAcceptance::DSL::Helpers.with_puppet_running_on failed (check backtrace for location) because: #{early_exception}\n#{early_exception.backtrace.join("\n")}\n")
+          raise(original_exception)
+
         ensure
-          restore_puppet_conf_from_backup( host )
+          begin
+            restore_puppet_conf_from_backup( host, backup_file )
 
-          if host.is_pe?
-            bounce_service( 'pe-httpd' )
+            if host.is_pe?
+              bounce_service( host, 'pe-httpd' )
+            else
+              stop_puppet_from_source_on( host ) if puppet_master_started
+            end
 
-          else
-            stop_puppet_from_source_on( host )
+          rescue Exception => teardown_exception
+            if original_exception
+              logger.error("Raised during attempt to teardown with_puppet_running_on: #{teardown_exception}\n---\n")
+              raise original_exception
+            else
+              raise teardown_exception
+            end
           end
         end
       end
 
       # @!visibility private
-      def restore_puppet_conf_from_backup( host )
+      def restore_puppet_conf_from_backup( host, backup_file = "#{puppetpath}/puppet.conf.bak" )
         puppetpath = host['puppetpath']
 
-        host.exec( Command.new( "if [ -f #{puppetpath}/puppet.conf.bak ]; then " +
-                                    "cat #{puppetpath}/puppet.conf.bak > " +
+        host.exec( Command.new( "if [ -f #{backup_file} ]; then " +
+                                    "cat #{backup_file} > " +
                                     "#{puppetpath}/puppet.conf; " +
-                                    "rm -rf #{puppetpath}/puppet.conf.bak; " +
+                                    "rm -f #{backup_file}; " +
                                 "fi" ) )
       end
 
       # @!visibility private
-      def backup_file host, current_dir, new_dir, filename = 'puppet.conf'
+      def backup_the_file host, current_dir, new_dir, filename = 'puppet.conf'
         old_location = current_dir + '/' + filename
-        new_location = new_dir + '/' + filename
+        new_location = new_dir + '/' + filename + '.bak'
 
         host.exec( Command.new( "cp #{old_location} #{new_location}" ) )
+
+        return new_location
       end
 
       # @!visibility private
-      def start_puppet_from_source_on! host
-        host.exec( Command.new( puppet( 'master' ) ) )
+      def start_puppet_from_source_on! host, args = ''
+        host.exec( puppet( 'master', args ) )
 
         logger.debug 'Waiting for the puppet master to start'
         unless port_open_within?( host, 8140, 10 )
           raise PuppetAcceptance::DSL::FailTest, 'Puppet master did not start in a timely fashion'
         end
         logger.debug 'The puppet master has started'
+        return true
       end
 
       # @!visibility private
@@ -375,10 +404,13 @@ module PuppetAcceptance
 
       # @!visibility private
       def lay_down_new_puppet_conf( host, configuration_options, testdir )
-        new_conf = puppet_conf_for( host )
+        new_conf = puppet_conf_for( host, configuration_options )
         create_remote_file host, "#{testdir}/puppet.conf", new_conf.to_s
 
-        host.exec( Command.new( "cat #{testdir}/puppet.conf > #{host['puppetpath']}/puppet.conf", :silent => true ) )
+        host.exec( 
+          Command.new( "cat #{testdir}/puppet.conf > #{host['puppetpath']}/puppet.conf" ),
+          :silent => true
+        )
         host.exec( Command.new( "cat #{host['puppetpath']}/puppet.conf" ) )
       end
 

--- a/lib/puppet_acceptance/dsl/helpers.rb
+++ b/lib/puppet_acceptance/dsl/helpers.rb
@@ -120,17 +120,17 @@ module PuppetAcceptance
 
       # Check to see if a package is installed on a remote host
       #
-      # @param [Host] host             A host object 
+      # @param [Host] host             A host object
       # @param [String] package_name   Name of the package to check for.
       #
-      # @return [Boolean] true/false if the package is found 
+      # @return [Boolean] true/false if the package is found
       def check_for_package host, package_name
         host.check_for_package package_name
       end
 
       # Install a package on a host
       #
-      # @param [Host] host             A host object 
+      # @param [Host] host             A host object
       # @param [String] package_name   Name of the package to install
       #
       # @return [Result]   An object representing the outcome of *install command*.
@@ -288,8 +288,7 @@ module PuppetAcceptance
       #
       # @param [Host] hosts        One object that act like Host
       #
-      # @param [Hash{Symbol=>String}]
-      #                            conf_opts Represent puppet settings.
+      # @param [Hash{Symbol=>String}] conf_opts  Represents puppet settings.
       #                            Sections of the puppet.conf may be
       #                            specified, if no section is specified the
       #                            a puppet.conf file will be written with the
@@ -303,6 +302,9 @@ module PuppetAcceptance
       #
       #                            These will only be applied when starting a FOSS
       #                            master, as a pe master is just bounced.
+      #
+      # @param [File] testdir      The temporary directory which will hold backup
+      #                            configuration, and other test artifacts.
       #
       # @param [Block]             block The point of this method, yields so
       #                            tests may be ran. After the block is finished
@@ -400,6 +402,24 @@ module PuppetAcceptance
       # @!visibility private
       def stop_puppet_from_source_on( host )
         host.exec( Command.new( 'kill $(cat `puppet master --configprint pidfile`)' ) )
+      rescue RuntimeError => e
+        dump_puppet_log host
+        raise e
+      end
+
+      # @!visibility private
+      def dump_puppet_log(host)
+        syslogfile = case host['platform']
+          when /fedora|centos|el/ then '/var/log/messages'
+          when /ubuntu|debian/ then '/var/log/syslog'
+          else return
+        end
+
+        logger.notify "\n*************************"
+        logger.notify "* Dumping master log    *"
+        logger.notify "*************************"
+        host.exec( Command.new( "tail -n 100 #{syslogfile}" ), :acceptable_exit_codes => [0,1])
+        logger.notify "*************************\n"
       end
 
       # @!visibility private
@@ -407,7 +427,7 @@ module PuppetAcceptance
         new_conf = puppet_conf_for( host, configuration_options )
         create_remote_file host, "#{testdir}/puppet.conf", new_conf.to_s
 
-        host.exec( 
+        host.exec(
           Command.new( "cat #{testdir}/puppet.conf > #{host['puppetpath']}/puppet.conf" ),
           :silent => true
         )

--- a/lib/puppet_acceptance/host/unix/pkg.rb
+++ b/lib/puppet_acceptance/host/unix/pkg.rb
@@ -7,13 +7,16 @@ module Unix::Pkg
   end
 
   def install_package name
-    if self['platform'] =~ /(fedora)|(centos)|(el)/
-      execute("yum -y install #{name}")
-    elsif self['platform'] =~ /(ubuntu)|(debian)/
-      execute("apt-get update")
-      execute("apt-get install -y #{name}")
-    else
-      raise "Package #{name} cannot be installed on #{host}"
+    case self['platform']
+      when /fedora|centos|el/
+        execute("yum -y install #{name}")
+      when /ubuntu|debian/
+        execute("apt-get update")
+        execute("apt-get install -y #{name}")
+      when /solaris/
+        execute("pkg install #{name}")
+      else
+        raise "Package #{name} cannot be installed on #{self}"
     end
   end
 

--- a/lib/puppet_acceptance/utils/repo_control.rb
+++ b/lib/puppet_acceptance/utils/repo_control.rb
@@ -58,7 +58,7 @@ module PuppetAcceptance
             apt_get_update
           when host['platform'] =~ /solaris-11/
             host.exec(Command.new("/usr/bin/pkg unset-publisher solaris || :"))
-            host.exec(Command.new(host,"/usr/bin/pkg set-publisher -g %s solaris" % IPS_PKG_REPO))
+            host.exec(Command.new("/usr/bin/pkg set-publisher -g %s solaris" % IPS_PKG_REPO))
           else
             @logger.debug "#{host}: repo proxy configuration not modified"
           end

--- a/spec/puppet-acceptance/dsl/helpers_spec.rb
+++ b/spec/puppet-acceptance/dsl/helpers_spec.rb
@@ -2,9 +2,15 @@ require 'spec_helper'
 
 class ClassMixedWithDSLHelpers
   include PuppetAcceptance::DSL::Helpers
+  include PuppetAcceptance::DSL::Wrappers
+
+  def logger
+    @logger ||= RSpec::Mocks::Mock.new('logger').as_null_object
+  end
 end
 
 describe ClassMixedWithDSLHelpers do
+
   describe '#on' do
     it 'allows the environment the command is run within to be specified' do
       host = double.as_null_object
@@ -225,6 +231,206 @@ describe ClassMixedWithDSLHelpers do
         with( 'my_host', 'forge.puppetlabs.com' => '127.0.0.1' )
 
       subject.stub_forge_on( 'my_host' )
+    end
+  end
+
+  describe '#with_puppet_running_on' do
+    class FakeHost
+      attr_accessor :commands
+
+      def initialize(options = {})
+        @pe = options[:pe]
+        @commands = []
+      end
+
+      def is_pe?
+        @pe
+      end
+
+      def any_exec_result
+        RSpec::Mocks::Mock.new('exec-result').as_null_object
+      end
+
+      def exec(command, options = {})
+        commands << command
+        any_exec_result
+      end
+
+      def command_strings
+        commands.map { |c| [c.command, c.args].join(' ') }
+      end
+    end
+
+    let(:is_pe) { false }
+    let(:host) { FakeHost.new(:pe => is_pe) }
+    let(:test_case_path) { 'testcase/path' }
+    let(:tmpdir_path) { '/tmp/tmpdir' }
+    let(:puppet_path) { '/puppet/path' }
+
+    def stub_host_and_subject_to_allow_the_default_testdir_argument_to_be_created
+      subject.instance_variable_set(:@path, test_case_path)
+      host.stub(:tmpdir).and_return(tmpdir_path)
+    end
+
+    RSpec::Matchers.define :execute_commands_matching do |pattern|
+
+      match do |actual|
+        @found_count = actual.command_strings.grep(pattern).size
+        @times.nil? ?
+          @found_count > 0 :
+          @found_count == @times
+      end
+
+      chain :exactly do |times|
+        @times = times
+      end
+
+      chain :times do
+        # clarity only
+      end
+
+      chain :once do
+        @times = 1
+        # clarity only
+      end
+
+      def message(actual, pattern, times, found_count)
+          msg = times == 1 ?
+            "#{pattern} once" :
+            "#{pattern} #{times} times"
+          msg += " but instead found a count of #{found_count}" if found_count != times
+          msg + " in:\n #{actual.command_strings.pretty_inspect}"
+      end
+
+      failure_message_for_should do |actual|
+        "Expected to find #{message(actual, pattern, @times, @found_count)}"
+      end
+
+      failure_message_for_should_not do |actual|
+        "Unexpectedly found #{message(actual, pattern, @times, @found_count)}"
+      end
+    end
+
+    before do
+      stub_host_and_subject_to_allow_the_default_testdir_argument_to_be_created
+      host.stub(:[]).and_return(puppet_path)
+    end
+
+    it "raises an ArgumentError if you try to submit a String instead of a Hash of options" do
+      expect { subject.with_puppet_running_on(host, '--foo --bar') }.to raise_error(ArgumentError, /conf_opts must be a Hash. You provided a String: '--foo --bar'/)
+    end
+
+    describe "with valid arguments" do
+      before do
+        Tempfile.should_receive(:open).with('puppet-acceptance')
+      end
+
+      context 'as pe' do
+        let(:is_pe) { true }
+
+        it 'bounces puppet twice' do
+          subject.with_puppet_running_on(host, {})
+          expect(host).to execute_commands_matching(/pe-httpd restart/).exactly(2).times
+        end
+
+        it 'yield to a block after bouncing service' do
+          execution = 0
+          expect do
+            subject.with_puppet_running_on(host, {}) do
+              expect(host).to execute_commands_matching(/pe-httpd restart/).once
+              execution += 1
+            end
+          end.to change { execution }.by(1)
+          expect(host).to execute_commands_matching(/pe-httpd restart/).exactly(2).times
+        end
+      end
+
+      context 'running from source' do
+
+        it 'does not try to stop if not started' do
+          subject.should_receive(:start_puppet_from_source_on!).and_return false
+          subject.should_not_receive(:stop_puppet_from_source_on)
+
+          subject.with_puppet_running_on(host, {})
+        end
+
+        context 'successfully' do
+          before do
+            host.should_receive(:port_open?).with(8140).and_return(true)
+          end
+
+          it 'starts puppet from source' do
+            subject.with_puppet_running_on(host, {})
+          end
+
+          it 'stops puppet from source' do
+            subject.with_puppet_running_on(host, {})
+            expect(host).to execute_commands_matching(/^kill.*puppet master --configprint pidfile/).once
+          end
+
+          it 'yields between starting and stopping' do
+            execution = 0
+            expect do
+              subject.with_puppet_running_on(host, {}) do
+                expect(host).to execute_commands_matching(/^puppet master/).once
+                execution += 1
+              end
+            end.to change { execution }.by(1)
+            expect(host).to execute_commands_matching(/^kill.*puppet master --configprint pidfile/).once
+          end
+
+          it 'passes on commandline args' do
+            subject.with_puppet_running_on(host, {:__commandline_args__ => '--with arg'})
+            expect(host).to execute_commands_matching(/^puppet master --with arg/).once
+          end
+        end
+      end
+
+      describe 'backup and restore of puppet.conf' do
+        let(:original_location) { "#{puppet_path}/puppet.conf" }
+        let(:backup_location) { "#{tmpdir_path}/puppet.conf.bak" }
+        let(:new_location) { "#{tmpdir_path}/puppet.conf" }
+
+        before do
+          host.should_receive(:port_open?).with(8140).and_return(true)
+        end
+
+        it 'backs up puppet.conf' do
+          subject.with_puppet_running_on(host, {})
+          expect(host).to execute_commands_matching(/cp #{original_location} #{backup_location}/).once
+          expect(host).to execute_commands_matching(/cat #{new_location} > #{original_location}/).once
+
+        end
+
+        it 'restores puppet.conf' do
+          subject.with_puppet_running_on(host, {})
+          expect(host).to execute_commands_matching(/cat #{backup_location} > #{original_location}/).once
+        end
+      end
+
+      describe 'handling failures' do
+        before do
+          subject.should_receive(:stop_puppet_from_source_on).and_raise(RuntimeError.new('Also failed in teardown.'))
+        end
+
+        it 'does not swallow an exception raised from within test block if ensure block also fails' do
+          host.should_receive(:port_open?).with(8140).and_return(true)
+
+          subject.logger.should_receive(:error).with(/Raised during attempt to teardown.*Also failed in teardown/)
+
+          expect do
+            subject.with_puppet_running_on(host, {}) { raise 'Failed while yielding.' }
+          end.to raise_error(RuntimeError, /failed.*because.*Failed while yielding./)
+        end
+
+        it 'does not swallow a teardown exception if no earlier exception was raised' do
+          host.should_receive(:port_open?).with(8140).and_return(true)
+          subject.logger.should_not_receive(:error)
+          expect do
+            subject.with_puppet_running_on(host, {})
+          end.to raise_error(RuntimeError, 'Also failed in teardown.')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
PuppetAcceptance::DSL::Helpers#with_puppet_running_on had incomplete
changes brought in from the pe Puppet::Acceptance::ConfigUtils, which I
think were being shadowed by the direct inclusion of ConfigUtils in
tests using with_puppet_running_on.

This patch finishes up the with_puppet_running_on implementation and
adds two things.  One a :**commandline_args** option to allow passing of
commandline flags to puppet in addition to configuration settings.  And
two, an attempt to ensure that errors raised during setup or execution
of the block are not masked by a failure in teardown.
